### PR TITLE
Port to Python 3 / Gedit 3.8

### DIFF
--- a/sourcecodebrowser.plugin
+++ b/sourcecodebrowser.plugin
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=sourcecodebrowser
 IAge=3
 Name=Source Code Browser

--- a/sourcecodebrowser/__init__.py
+++ b/sourcecodebrowser/__init__.py
@@ -1,3 +1,2 @@
-import plugin
-from plugin import SourceCodeBrowserPlugin
-
+from . import plugin
+from .plugin import SourceCodeBrowserPlugin

--- a/sourcecodebrowser/ctags.py
+++ b/sourcecodebrowser/ctags.py
@@ -88,8 +88,8 @@ class Parser(object):
         #args = [arg.replace('%20', ' ') for arg in shlex.split(command)] 
         args = shlex.split(command)
         p = subprocess.Popen(args, 0, shell=False, stdout=subprocess.PIPE, executable=executable)
-        symbols = self._parse_text(p.communicate()[0])
-    
+        symbols = self._parse_text(p.communicate()[0].decode('utf8'))
+
     def _parse_text(self, text):
         """
         Parses ctags text which may have come from a TAG file or from raw output

--- a/sourcecodebrowser/plugin.py
+++ b/sourcecodebrowser/plugin.py
@@ -2,7 +2,7 @@ import os
 import sys
 import logging
 import tempfile
-import ctags
+from . import ctags
 from gi.repository import GObject, GdkPixbuf, Gedit, Gtk, PeasGtk, Gio
 
 logging.basicConfig()


### PR DESCRIPTION
Gedit 3.8 switched to Python 3 for its plugins.
